### PR TITLE
Fix `ArgumentCountError` in `_drupal_error_handler` for PHP:^8

### DIFF
--- a/includes/common.inc
+++ b/includes/common.inc
@@ -3926,7 +3926,7 @@ define('ERROR_REPORTING_DISPLAY_ALL', 2);
  * @param $context
  *   An array that points to the active symbol table at the point the error occurred.
  */
-function _drupal_error_handler($error_level, $message, $filename, $line, $context) {
+function _drupal_error_handler($error_level, $message, $filename, $line, $context = NULL) {
   if ($error_level & error_reporting()) {
     // All these constants are documented at http://php.net/manual/en/errorfunc.constants.php
     $types = array(


### PR DESCRIPTION
```
Fatal error: Uncaught ArgumentCountError: Too few arguments to function _drupal_error_handler(), 4 passed and exactly 5 expected in /var/www/includes/common.inc on line 3929
```